### PR TITLE
fixes arguments incompatibility with setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
 'use strict';
 module.exports = typeof setImmediate === 'function' ? setImmediate :
-	function setImmediate(fn) { setTimeout(fn, 0); };
+  function setImmediate() {
+    var args = Array.prototype.slice.apply(arguments);
+    var fn = args.shift();
+    console.log('fn', fn, 'args', args);
+    setTimeout(function() {
+      fn.apply(null, args);
+    }, 0);
+  };

--- a/test.js
+++ b/test.js
@@ -18,3 +18,21 @@ test(function (t) {
 
 	t.assert(!called);
 });
+
+test(function (t) {
+	var called = false;
+
+	// force the shim
+	var _ = setImmediate;
+	setImmediate = null;
+	var setImmediateShim = requireUncached('./');
+	setImmediate = _;
+
+	setImmediateShim(function (a, b) {
+		var max = Math.max(a, b);
+		console.log('max', max)
+		t.assert(max === 5);
+		t.end();
+	}, 3, 5);
+	t.assert(!called);
+});


### PR DESCRIPTION
`setImmediate` takes these parameters: `setImmediate(func, [param1, param2, ...]);`
`setTimeout` uses these: setTimeout(code, delay);

This PR fixes this incompatibility and adds a test case with arguments
 